### PR TITLE
chore: don't use `::f` placeholders

### DIFF
--- a/app/BlueprintFramework/Libraries/ExtensionLibrary/Admin/BlueprintAdminLibrary.php
+++ b/app/BlueprintFramework/Libraries/ExtensionLibrary/Admin/BlueprintAdminLibrary.php
@@ -145,7 +145,7 @@ class BlueprintAdminLibrary
    * [BlueprintExtensionLibrary documentation](https://blueprint.zip/docs/?page=documentation/$blueprint)
    */
   public function extension($identifier): bool {
-    if(str_contains($this->fileRead("::f/.blueprint/extensions/blueprint/private/db/installed_extensions"), $identifier.',')) {
+    if(str_contains($this->fileRead(base_path(".blueprint/extensions/blueprint/private/db/installed_extensions")), $identifier.',')) {
       return true;
     } else {
       return false;

--- a/app/BlueprintFramework/Libraries/ExtensionLibrary/Client/BlueprintClientLibrary.php
+++ b/app/BlueprintFramework/Libraries/ExtensionLibrary/Client/BlueprintClientLibrary.php
@@ -102,7 +102,7 @@ class BlueprintClientLibrary
    * [BlueprintExtensionLibrary documentation](https://blueprint.zip/docs/?page=documentation/$blueprint)
    */
   public function extension($identifier): bool {
-    if(str_contains($this->fileRead("::f/.blueprint/extensions/blueprint/private/db/installed_extensions"), $identifier.',')) {
+    if(str_contains($this->fileRead(base_path(".blueprint/extensions/blueprint/private/db/installed_extensions")), $identifier.',')) {
       return true;
     } else {
       return false;

--- a/app/BlueprintFramework/Services/PlaceholderService/BlueprintPlaceholderService.php
+++ b/app/BlueprintFramework/Services/PlaceholderService/BlueprintPlaceholderService.php
@@ -5,7 +5,7 @@ namespace Pterodactyl\BlueprintFramework\Services\PlaceholderService;
 class BlueprintPlaceholderService
 {
   public function version(): string { return "::v"; }
-  public function folder(): string { return "::f"; }
+  public function folder(): string { return base_path(); }
   public function installed(): string { return "NOTINSTALLED"; }
   public function api_url(): string { return "http://api.blueprint.zip:50000"; }
 }

--- a/blueprint.sh
+++ b/blueprint.sh
@@ -6,7 +6,8 @@
 
 # This should allow Blueprint to run in Docker. Please note that changing the $FOLDER variable after running
 # the Blueprint installation script will not change anything in any files besides blueprint.sh.
-  FOLDER="/var/www/pterodactyl" #;
+  FOLDER="$(realpath $(dirname $0))" #;
+# Technically shouldn't be needed now, but I'm not going to touch this for now just in case it breaks stuff on Docker. -- @itsvic-dev
   DOCKERFOLDER="/app"
 
 # This stores the webserver ownership user which Blueprint uses when applying webserver permissions.
@@ -222,11 +223,6 @@ if [[ $1 != "-bash" ]]; then
     php artisan storage:link &>> $BLUEPRINT__DEBUG 
 
     PRINT INFO "Replacing internal placeholders.."
-    # Update folder placeholder on PlaceholderService and admin layout.
-    # Should avoid doing stuff this way in the future!
-    sed -i "s~::f~$FOLDER~g" $FOLDER/app/BlueprintFramework/Services/PlaceholderService/BlueprintPlaceholderService.php
-    sed -i "s~::f~$FOLDER~g" $FOLDER/app/BlueprintFramework/Libraries/ExtensionLibrary/Admin/BlueprintAdminLibrary.php
-    sed -i "s~::f~$FOLDER~g" $FOLDER/app/BlueprintFramework/Libraries/ExtensionLibrary/Client/BlueprintClientLibrary.php
     # Copy "Blueprint" extension page logo from assets.
     cp $FOLDER/.blueprint/assets/logo.jpg $FOLDER/.blueprint/extensions/blueprint/assets/logo.jpg
 


### PR DESCRIPTION
Uses the `base_path()` function in place of the `::f` placeholder. Additionally fetches the folder from wherever `blueprint.sh` is, which should always be in the panel.

> [!WARNING]
> **I DID NOT TEST THIS.** I don't have a vanilla Pterodactyl + Blueprint installation to test this with.
> @prplwtf, please make sure this works as expected before merging.
> Especially test things such as `/usr/local/bin/blueprint` generation and execution.