### PR TITLE
Fix for ISO-8859-6

### DIFF
--- a/blueprint.sh
+++ b/blueprint.sh
@@ -32,6 +32,20 @@ export BLUEPRINT__VERSION=$VERSION
 export BLUEPRINT__DEBUG="$FOLDER"/.blueprint/extensions/blueprint/private/debug/logs.txt
 export NODE_OPTIONS=--openssl-legacy-provider
 
+# Check Locale of system. If not UTF-8 routes will fail when installing extensions on some OS'. It's stupid.
+current_encoding=$(locale charmap 2>/dev/null)
+
+# If current locale is not UTF-8, print error.
+if [[ "$current_encoding" != "UTF-8" ]]; then
+  echo "Error: System locale encoding is '$current_encoding'."
+  echo "Please set your locale to a UTF-8 variant (e.g., en_US.UTF-8) instead of '$current_encoding'."
+  echo "Ubuntu/Debian: run 'dpkg-reconfigure locales'
+  echo "Rocky/Alma/CentOS/RHEL: run 'localectl set-locale LANG=en_US.UTF-8'
+  
+  exit 1
+fi
+
+
 # Check if the script is being sourced - and if so - load bash autocompletion.
 if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
   _blueprint_completions() {

--- a/blueprint.sh
+++ b/blueprint.sh
@@ -40,7 +40,7 @@ if [[ "$current_encoding" != "UTF-8" ]]; then
   echo "Error: System locale encoding is '$current_encoding'."
   echo "Please set your locale to a UTF-8 variant (e.g., en_US.UTF-8) instead of '$current_encoding'."
   echo "Ubuntu/Debian: run 'dpkg-reconfigure locales'
-  echo "Rocky/Alma/CentOS/RHEL: run 'localectl set-locale LANG=en_US.UTF-8'
+  echo "Rocky/Alma/CentOS/RHEL: run 'localectl set-locale LANG=en_US.UTF-8'"
   
   exit 1
 fi


### PR DESCRIPTION
Added check at start of blueprint.sh to:
* Check locale for UTF-8
* Print error if not UTF-8
* Provide instructions to fix.