### PR TITLE
fix: docker extension removal

### DIFF
--- a/scripts/commands/extensions/remove.sh
+++ b/scripts/commands/extensions/remove.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 RemoveExtension() {
-  if [[ $USER_CONFIRMED_REMOVAL != "yes" ]]; then
+  if [[ $USER_CONFIRMED_REMOVAL != "yes" || $3 != "-user-confirmed-removal" ]]; then
     PRINT INPUT "Do you want to proceed with this transaction? Some files might not be removed properly. (y/N)"
     hide_progress
     read -r YN


### PR DESCRIPTION
I added a flag because exporting in the docker container is not available.

```
$ docker compose exec panel export USER_CONFIRMED_REMOVAL="yes"
OCI runtime exec failed: exec failed: unable to start container process: exec: "export": executable file not found in $PATH: unknown
```

it is not found in `/bin` there should be a path `/bin/export` that should be there to export  env, but there is not that's why it fails.

via using this docker image: https://github.com/BlueprintFramework/docker/blob/Master/docker-compose.yml

I also mentioned this in the discord I was told by @prplwtf there will be a flag implemented soon, but I need this asap so here is the pr. [Link to message](https://discord.com/channels/1063548024825057451/1094949482535321690/1350024147371167765)