### PR TITLE
feat: allow clone from specific branch

### DIFF
--- a/scripts/commands/advanced/upgrade.sh
+++ b/scripts/commands/advanced/upgrade.sh
@@ -61,7 +61,11 @@ Command() {
     fi
     # download release
     hide_progress
-    git clone "$REMOTE_REPOSITORY" main
+    if [[ $3 == "" ]]; then
+      git clone "$REMOTE_REPOSITORY" main
+    else
+      git clone "$REMOTE_REPOSITORY" main --branch "$3"
+    fi
   else
     # download latest release
     hide_progress


### PR DESCRIPTION
Simple change, allow contributors (or anyone) to "upgrade" from a branch on their fork for easier testing.

Syntax would be `blueprint -upgrade remote BlueprintFramework/framework branch-name`