### PR TITLE
Fixes https://github.com/BlueprintFramework/framework/issues/213

### DIFF
--- a/blueprint.sh
+++ b/blueprint.sh
@@ -477,10 +477,12 @@ esac
 shift 2
 
 # prevent interesting freakout when passing "*" as an argument
-if [[ $* == *"*"* ]]; then
-  PRINT FATAL "\"*\" cannot be used as an argument."
-  exit 2
-fi
+for arg in "$@"; do
+  if [[ "$arg" == "*" ]]; then
+    PRINT FATAL "\"*\" cannot be used as an argument."
+    exit 2
+  fi
+done
 
 Command "$@"
 exit 0


### PR DESCRIPTION
The check evaluates each argument individually now, rather than "is * in any argument anywhere"