### PR TITLE
feat: add 10s countdown before running custom extension scripts

### DIFF
--- a/scripts/commands/extensions/install.sh
+++ b/scripts/commands/extensions/install.sh
@@ -178,7 +178,7 @@ InstallExtension() {
     # run extension update script
     if [[ -f ".blueprint/extensions/$identifier/private/update.sh" ]]; then
       PRINT WARNING "Extension uses a custom update script, proceed with caution."
-      hide_progress
+      blueprint_custom_script_confirm "update"
       chmod --silent +x ".blueprint/extensions/$identifier/private/update.sh" 2>> "$BLUEPRINT__DEBUG"
 
 
@@ -1308,7 +1308,7 @@ InstallExtension() {
   if [[ ( $F_developerIgnoreInstallScript == false ) || ( $dev != true ) ]]; then
     if [[ -f ".blueprint/extensions/$identifier/private/install.sh" ]]; then
       PRINT WARNING "Extension uses a custom installation script, proceed with caution."
-      hide_progress
+      blueprint_custom_script_confirm "installation"
       chmod --silent +x ".blueprint/extensions/$identifier/private/install.sh" 2>> "$BLUEPRINT__DEBUG"
 
       # Run script while also parsing some useful variables for the install script to use.

--- a/scripts/commands/extensions/remove.sh
+++ b/scripts/commands/extensions/remove.sh
@@ -91,7 +91,7 @@ RemoveExtension() {
 
   if [[ -f ".blueprint/extensions/$identifier/private/remove.sh" ]]; then
     PRINT WARNING "Extension uses a custom removal script, proceed with caution."
-    hide_progress
+    blueprint_custom_script_confirm "removal"
     chmod +x ".blueprint/extensions/$identifier/private/remove.sh"
 
     # Run script while also parsing some useful variables for the uninstall script to use.

--- a/scripts/libraries/misc.sh
+++ b/scripts/libraries/misc.sh
@@ -103,3 +103,25 @@ extract_extension() {
 
   return 0
 }
+
+
+blueprint_custom_script_confirm() {
+  local phase="$1"
+  local deadline remaining
+
+  if [[ ! -t 0 ]] || [[ -n "${BLUEPRINT_SKIP_SCRIPT_CONFIRM:-}" ]]; then
+    return 0
+  fi
+
+  hide_progress
+
+  deadline=$((SECONDS + 10))
+
+  while [[ $SECONDS -lt $deadline ]]; do
+    remaining=$((deadline - SECONDS))
+    printf "\r\033[2m%s\033[0m \x1b[35;1mInput:\x1b[0m Extension has a custom %s script. Press \x1b[32;1m[ENTER]\x1b[0m to continue or \x1b[31;1m^C\x1b[0m to abort. \x1b[2m(auto-proceeding in %ds)\x1b[0m   " "$(date +"%H:%M:%S")" "$phase" "$remaining"
+    read -r -t 1 && { printf "\r\033[K"; return 0; }
+  done
+
+  printf "\r\033[K"
+}


### PR DESCRIPTION
when an extension ships a custom install, update or removal script, blueprint prints a caution warning and immediately runs it. theres no pause, so if you see the warning and want to check whats in the script before it runs, youre already too late.

this adds a 10 second countdown prompt before any of those scripts execute. you can hit enter to go immediately or ctrl+c to bail out clean. non-interactive environments (pipes, ci) skip the wait automatically, and theres a `BLUEPRINT_SKIP_SCRIPT_CONFIRM` env var if you want to disable it manually.

**files changed**
- `scripts/libraries/misc.sh` - added `blueprint_custom_script_confirm()`, sourced globally via `blueprint.sh`
- `scripts/commands/extensions/install.sh` - update path + install path
- `scripts/commands/extensions/remove.sh` - removal path