### PR TITLE
fix: improve YAML configuration handling and normalize exports

### DIFF
--- a/scripts/commands/developer/export.sh
+++ b/scripts/commands/developer/export.sh
@@ -17,6 +17,11 @@ Command() {
   cp -r dev/* tmp/
   cd tmp || cdhalt
 
+  if ! node "$FOLDER/scripts/helpers/normalize-conf-yaml.js" conf.yml; then
+    PRINT FATAL "Unable to normalize extension configuration to UTF-8."
+    return 1
+  fi
+
   # Assign variables to extension flags.
   flags="$conf_info_flags"
   PRINT INFO "Reading and assigning extension flags.."

--- a/scripts/commands/extensions/install.sh
+++ b/scripts/commands/extensions/install.sh
@@ -148,7 +148,17 @@ InstallExtension() {
       return 1
     fi
 
-    eval "$(parse_yaml .blueprint/extensions/"${identifier}"/private/.store/conf.yml old_)"
+    while IFS= read -r assignment; do
+      if [[ -z "$assignment" ]]; then
+        continue
+      fi
+
+      if [[ $assignment =~ ^old_[a-zA-Z0-9_]*= ]]; then
+        eval "$assignment"
+      else
+        PRINT WARNING "Ignoring malformed stored extension configuration entry while updating '$identifier'."
+      fi
+    done < <(parse_yaml ".blueprint/extensions/${identifier}/private/.store/conf.yml" old_)
     local DUPLICATE="y"
 
     # run extension update script

--- a/scripts/commands/extensions/remove.sh
+++ b/scripts/commands/extensions/remove.sh
@@ -30,7 +30,17 @@ RemoveExtension() {
   ((PROGRESS_NOW++))
 
   if [[ -f ".blueprint/extensions/$EXTENSION/private/.store/conf.yml" ]]; then
-    eval "$(parse_yaml ".blueprint/extensions/$EXTENSION/private/.store/conf.yml" conf_)"
+    while IFS= read -r assignment; do
+      if [[ -z "$assignment" ]]; then
+        continue
+      fi
+
+      if [[ $assignment =~ ^conf_[a-zA-Z0-9_]*= ]]; then
+        eval "$assignment"
+      else
+        PRINT WARNING "Ignoring malformed stored extension configuration entry while removing '$EXTENSION'."
+      fi
+    done < <(parse_yaml ".blueprint/extensions/${EXTENSION}/private/.store/conf.yml" conf_)
     # Add aliases for config values to make working with them easier.
     local name="${conf_info_name//&/\\&}"
     local identifier="${conf_info_identifier//&/\\&}"

--- a/scripts/helpers/normalize-conf-yaml.js
+++ b/scripts/helpers/normalize-conf-yaml.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+
+const path = process.argv[2];
+
+if (!path) {
+  console.error('Usage: node normalize-conf-yaml.js <conf.yml>');
+  process.exit(1);
+}
+
+let contents;
+
+try {
+  contents = fs.readFileSync(path);
+} catch {
+  console.error(`Unable to read ${path}.`);
+  process.exit(1);
+}
+
+let encoding = 'utf-8';
+let offset = 0;
+
+if (contents.subarray(0, 3).equals(Buffer.from([0xef, 0xbb, 0xbf]))) {
+  offset = 3;
+} else if (contents.subarray(0, 2).equals(Buffer.from([0xff, 0xfe]))) {
+  encoding = 'utf-16le';
+  offset = 2;
+} else if (contents.subarray(0, 2).equals(Buffer.from([0xfe, 0xff]))) {
+  encoding = 'utf-16be';
+  offset = 2;
+}
+
+try {
+  const text = new TextDecoder(encoding, { fatal: true }).decode(contents.subarray(offset));
+  fs.writeFileSync(path, text, 'utf8');
+} catch {
+  console.error(`Unable to convert ${path} to UTF-8.`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- guard stored extension YAML parsing during updates and removals
- normalize exported `conf.yml` files to UTF-8 without a BOM

## Root cause

Legacy stored configuration could cause the YAML parser to emit malformed shell assignments. The install and remove flows evaluated that output directly, resulting in errors such as `=: command not found`. Extension configuration saved with a UTF-8 BOM or UTF-16 encoding could also fail parsing after export.

## Changes

Stored configuration parsing now accepts only the expected generated variable assignments and warns when malformed entries are ignored. Exported extension configuration is normalized through a Node helper before it is packaged, removing UTF-8 BOMs and converting BOM-marked UTF-16 files to UTF-8.

## Validation

- verified UTF-8 BOM removal
- verified UTF-16 to UTF-8 conversion
